### PR TITLE
[WIP] Interpolate CONDPROP_UNADJ corectly so it sums to 1

### DIFF
--- a/R/fia_annualize.R
+++ b/R/fia_annualize.R
@@ -1,10 +1,10 @@
 #' Create annualized FIA data
-#' 
+#'
 #' Converts tidied panel data into annualized data with interpolated measurments
 #' for trees for years between inventories. This happens in three steps, which
 #' can be "manually" replicated by chaining other `forestTIME.builder`
 #' functions.
-#' 
+#'
 #' First, data is expanded by [expand_data()] to add rows for years between
 #' inventories for each tree in the data. Next, data is interpolated with
 #' [interpolate_data()]. Finally, [adjust_mortality()] is applied. For trees
@@ -13,22 +13,86 @@
 #' midpoint between surveys, rounded down. Unlike these intermediate functions,
 #' `fia_annualize()` produces a dataset which can be safely used for other
 #' analyses (with the caveat that all of this is experimental).
-#' 
+#'
 #' @note Most users should use this "wrapper" function rather than running each
 #' step separately since the intermediate steps may contain data artifacts.
 #' However, one reason to use the stepwise workflow would be to save time when
 #' generating interpolated data with and without using `MORTYR` as
 #' `interpolate_data()` is the slowest step.
-#' 
+#'
 #' @seealso For more details on each step, see: [expand_data()],
-#'   [interpolate_data()], [adjust_mortality()] 
+#'   [interpolate_data()], [adjust_mortality()]
 #' @param data_tidy A tibble produced by [fia_tidy()].
 #' @param use_mortyr logical; Use `MORTYR` (if recorded) as the first year a
 #'   tree was dead? Passed to [adjust_mortality()].
 #' @export
 fia_annualize <- function(data_tidy, use_mortyr = TRUE) {
-  data_tidy |> 
-    expand_data() |> 
-    interpolate_data() |> 
+  
+  # TODO: you *need* to move this into interpolate_data() so the step-wise
+  # workflow still works
+
+  # Interpolate COND table separately to account for the number of conditions
+  # (CONDIDs) changing from year to year
+  # https://github.com/Evans-Ecology-Lab/forestTIME-builder/issues/64
+
+  cond <- data_tidy |>
+    dplyr::group_by(plot_ID, INVYR, CONDID) |>
+    dplyr::filter(!is.na(CONDID)) |>
+    dplyr::summarize(
+      CONDPROP_UNADJ = dplyr::first(CONDPROP_UNADJ), #they *should* all be the same
+      .groups = "drop"
+    )
+
+  all_conds <- cond |>
+    dplyr::group_by(plot_ID) |>
+    tidyr::expand(
+      CONDID = unique(CONDID),
+      INVYR = unique(INVYR)
+    )
+
+  cond_complete <- dplyr::full_join(cond, all_conds) |>
+    dplyr::mutate(
+      CONDPROP_UNADJ = dplyr::if_else(
+        is.na(CONDPROP_UNADJ) & !is.na(CONDID),
+        0,
+        CONDPROP_UNADJ
+      )
+    )
+
+  cond_all_years <-
+    cond_complete |>
+    dplyr::group_by(plot_ID) |>
+    tidyr::expand(CONDID, YEAR = tidyr::full_seq(INVYR, 1))
+
+  cond_expanded <- dplyr::right_join(
+    cond_complete,
+    cond_all_years,
+    by = dplyr::join_by(plot_ID, CONDID, INVYR == YEAR)
+  ) |>
+    dplyr::arrange(plot_ID, INVYR, CONDID)
+
+  cond_interpolated <-
+    cond_expanded |>
+    rename(YEAR = INVYR) |>
+    group_by(plot_ID, CONDID) |>
+    dplyr::mutate(
+      CONDPROP_UNADJ = inter_extra_polate(
+        YEAR,
+        CONDPROP_UNADJ,
+        extrapolate = FALSE
+      )
+    )
+  # cond_interpolated is missing some CONDIDs because they apparently aren't all
+  # there in the tidied data.  I thought I had fixed that and kept any rows with
+  # no trees, but maybe I just kept *plots* with no trees and not plot * CONDID
+  # combinations.
+
+  data_interpolated <- data_tidy |>
+    expand_data() |>
+    interpolate_data()
+
+  left_join(data_interpolated |> select(-CONDPROP_UNADJ), cond_interpolated) |>
     adjust_mortality(use_mortyr = use_mortyr)
+
 }
+

--- a/R/fia_tidy.R
+++ b/R/fia_tidy.R
@@ -22,13 +22,13 @@ fia_tidy <- function(db) {
   PLOTGEOM <-
     db$PLOTGEOM |>
     dplyr::filter(INVYR >= 2000L) |>
-    dplyr::mutate(CN = as.character(CN)) |> 
+    dplyr::mutate(CN = as.character(CN)) |>
     dplyr::select(PLT_CN = CN, INVYR, ECOSUBCD)
 
   PLOT <-
     db$PLOT |>
     dplyr::filter(INVYR >= 2000L) |>
-    dplyr::mutate(CN = as.character(CN)) |> 
+    dplyr::mutate(CN = as.character(CN)) |>
     fia_add_composite_ids() |>
     dplyr::select(
       plot_ID,
@@ -42,7 +42,7 @@ fia_tidy <- function(db) {
   COND <-
     db$COND |>
     dplyr::filter(INVYR >= 2000L) |>
-    dplyr::mutate(PLT_CN = as.character(PLT_CN)) |> 
+    dplyr::mutate(PLT_CN = as.character(PLT_CN)) |>
     fia_add_composite_ids() |>
     dplyr::select(
       plot_ID,
@@ -58,7 +58,7 @@ fia_tidy <- function(db) {
   TREE <-
     db$TREE |>
     dplyr::filter(INVYR >= 2000L) |>
-    dplyr::mutate(PLT_CN = as.character(PLT_CN)) |> 
+    dplyr::mutate(PLT_CN = as.character(PLT_CN)) |>
     fia_add_composite_ids() |>
     dplyr::select(
       plot_ID,
@@ -81,14 +81,13 @@ fia_tidy <- function(db) {
 
   # Join the tables
   data <-
-    PLOT |>
+    COND |>
     dplyr::as_tibble() |>
-    dplyr::left_join(TREE, by = dplyr::join_by(plot_ID, PLT_CN, INVYR)) |>
-    dplyr::left_join(PLOTGEOM, by = dplyr::join_by(INVYR, PLT_CN)) |>
-    dplyr::left_join(COND, by = dplyr::join_by(plot_ID, INVYR, PLT_CN, CONDID))
+    dplyr::left_join(TREE, by = dplyr::join_by(plot_ID, PLT_CN, CONDID, INVYR)) |>
+    dplyr::left_join(PLOT, by = dplyr::join_by(plot_ID, PLT_CN, INVYR)) |> 
+    dplyr::left_join(PLOTGEOM, by = dplyr::join_by(INVYR, PLT_CN))
 
-
-  # use only base intensity plots 
+  # use only base intensity plots
   # data <- data |>
   #   dplyr::filter(INTENSITY == 1)
 
@@ -113,29 +112,29 @@ fia_tidy <- function(db) {
     dplyr::mutate(ACTUALHT = dplyr::coalesce(ACTUALHT, HT))
 
   #   # deal with "problem" trees
-    # data <- data |>
-    #   dplyr::group_by(tree_ID) |>
-    #   dplyr::filter(
-    #     sum(!is.na(DIA)) > 1 & sum(!is.na(HT)) > 1
-    #   ) |>
-    #   # remove trees that have always been fallen and have no measurements
-    #   dplyr::filter(
-    #     !(sum(is.finite(DIA) & is.finite(HT)) == 0 & all(STANDING_DEAD_CD == 0))
-    #   ) |>
-    #   # remove trees that were measured in error
-    #   # (https://github.com/mekevans/forestTIME-builder/issues/59#issuecomment-2758575994)
-    #   dplyr::filter(!any(RECONCILECD %in% c(7, 8))) |>
-    #   dplyr::ungroup() |>
+  # data <- data |>
+  #   dplyr::group_by(tree_ID) |>
+  #   dplyr::filter(
+  #     sum(!is.na(DIA)) > 1 & sum(!is.na(HT)) > 1
+  #   ) |>
+  #   # remove trees that have always been fallen and have no measurements
+  #   dplyr::filter(
+  #     !(sum(is.finite(DIA) & is.finite(HT)) == 0 & all(STANDING_DEAD_CD == 0))
+  #   ) |>
+  #   # remove trees that were measured in error
+  #   # (https://github.com/mekevans/forestTIME-builder/issues/59#issuecomment-2758575994)
+  #   dplyr::filter(!any(RECONCILECD %in% c(7, 8))) |>
+  #   dplyr::ungroup() |>
 
-    # join the empty plots back in
-    data <-
-      dplyr::full_join(
-        data,
-        all_plots,
-        by = dplyr::join_by(plot_ID, PLT_CN, INVYR, DESIGNCD, INTENSITY)
-      ) |>
-      dplyr::arrange(plot_ID, tree_ID, INVYR) |>
-      dplyr::select(plot_ID, tree_ID, INVYR, everything())
+  # join the empty plots back in
+  data <-
+    dplyr::full_join(
+      data,
+      all_plots,
+      by = dplyr::join_by(plot_ID, PLT_CN, INVYR, DESIGNCD, INTENSITY)
+    ) |>
+    dplyr::arrange(plot_ID, tree_ID, INVYR) |>
+    dplyr::select(plot_ID, tree_ID, INVYR, everything())
 
   # return:
   data

--- a/R/interpolate_data.R
+++ b/R/interpolate_data.R
@@ -51,7 +51,10 @@ interpolate_data <- function(data_expanded) {
   )
 
   data_interpolated <- data_expanded |>
-    dplyr::group_by(plot_ID, tree_ID) |>
+    # CONDID added as a grouping variable because rows with NA for tree_ID, but
+    # two different conditions were being treated as the same tree and erroring
+    # in approx(). E.g. approx(x = c(2006,2006), y = c(0,0), xout = c(2006,2006))
+    dplyr::group_by(plot_ID, tree_ID, CONDID) |> 
     dplyr::mutate(
       #linearly interpolate/extrapolate
       dplyr::across(

--- a/vignettes/pop_scaling.qmd
+++ b/vignettes/pop_scaling.qmd
@@ -44,6 +44,7 @@ The interpolated values produced by `forestTIME.builder` are *inferences* and no
 
 ```{r}
 #| label: rfia-biomass
+
 agc_rfia_annual <-
   biomass(
     fiaRI,
@@ -72,6 +73,7 @@ agc_rfia_ti <-
 mean(agc_rfia_annual$carbon_ton_acre)
 mean(agc_rfia_ti$carbon_ton_acre)
 ```
+
 :::
 
 ```{r}
@@ -80,9 +82,9 @@ mean(agc_rfia_ti$carbon_ton_acre)
 
 state <- "RI"
 db <- fia_load(
-    "RI",
-    dir = system.file("exdata", package = "forestTIME.builder")
-  )
+  "RI",
+  dir = system.file("exdata", package = "forestTIME.builder")
+)
 data <- fia_tidy(db) #single tibble
 data_midpt <- data |>
   fia_annualize(use_mortyr = FALSE) |>
@@ -92,6 +94,7 @@ data_midpt <- data |>
 ```{r}
 #| label: annualize-data
 #| eval: false
+
 state <- "RI"
 
 # Data Download
@@ -119,6 +122,7 @@ So we can't just `filter(STATUSCD == 1 & COND_STATUSCD == 1)` to estimate carbon
 
 ```{r}
 #| label: domain-indicators
+
 data_midpt <-
   data_midpt |>
   mutate(
@@ -136,6 +140,7 @@ We think these `EXPNS` values can be used much in the same way as the ones in th
 
 ```{r}
 #| label: expns
+
 data_midpt |>
   select(YEAR, EXPNS) |>
   group_by(YEAR) |>
@@ -168,22 +173,28 @@ area_totals <- data_midpt |>
     forArea = sum(CONDPROP_UNADJ * EXPNS * aDI, na.rm = TRUE) #acres/plot
   )
 
-agc_pop <- inner_join(tree_totals, area_totals) |> 
-  group_by(YEAR) |> 
+agc_pop <- inner_join(tree_totals, area_totals) |>
+  group_by(YEAR) |>
   summarize(
     CARB_AG_TOTAL = sum(carbPlot, na.rm = TRUE), # tons/plot
     AREA_TOTAL = sum(forArea, na.rm = TRUE) # acres/plot
   ) |>
   # the units work out to still be tons(live carbon)/acre(forested land) even if the variable names are misleading
   mutate(method = "forestTIME", carbon_ton_acre = CARB_AG_TOTAL / AREA_TOTAL) |>
-  select(method, YEAR, carbon_ton_acre, carbon_total = CARB_AG_TOTAL, AREA_TOTAL)
+  select(
+    method,
+    YEAR,
+    carbon_ton_acre,
+    carbon_total = CARB_AG_TOTAL,
+    AREA_TOTAL
+  )
 agc_pop
 ```
 
 ```{r}
 #| label: plot-results
 
-all <- bind_rows(agc_rfia_annual, agc_rfia_ti, agc_pop) 
+all <- bind_rows(agc_rfia_annual, agc_rfia_ti, agc_pop)
 
 ggplot(all, aes(x = YEAR, y = carbon_total, color = method)) +
   geom_line() +


### PR DESCRIPTION
This is a fix for #64.  So far:

- Moves join order in `fia_tidy()` so it starts with the COND table ensuring that any "empty" conditions (i.e. `CONDID`s with no corresponding `tree_ID`s) remain accounted for in the final data.
- Expands and interpolates the COND table separately in a way that ensures `CONDPROP_UNADJ` always sums to 1 in every year x plot combination


Still to do:

- Move COND table interpolation logic somewhere so the stepwise workflow (`fia_tidy() |> expand_data() |> interpolate_data() |> adjust_mortality()`) still works. Might need to combine `expand_data()` and `interpolate_data()` into one function.  Main point is to keep `adjust_mortality()` separate)