### PR TITLE
Link to releases in separate repo

### DIFF
--- a/.github/workflows/run_workflow.yml
+++ b/.github/workflows/run_workflow.yml
@@ -1,16 +1,4 @@
 on:
-  push:
-    branches: [main, master]
-    #don't re-run if changes are just "cosmetic"
-    paths-ignore:
-      - 'README*'
-      - 'LICENSE*'
-      - 'docs/**'
-      - 'doc/**'
-      - 'man/**'
-      - 'vignettes/**'
-      - 'CITATION.cff'
-      - 'NEWS.md'
   pull_request:  
     #don't re-run if changes are just "cosmetic"
     paths-ignore:
@@ -22,37 +10,16 @@ on:
       - 'vignettes/**'
       - 'CITATION.cff'
       - 'NEWS.md'
-  workflow_dispatch:
-  #   # TODO eventually add schedule?
-  # schedule:
-  #   - cron: 
 
 name: run_workflow.yml
 
 jobs:
-  define-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      states: ${{ steps.set-matrix.outputs.states }}
-    steps:
-      - name: Define states
-        id: set-matrix
-        #define states that run when it is a pull-request (as a test) and on main (to produce useful data)
-        run: |
-          isPR=$(echo '${{ github.event_name == 'pull_request'}}')
-          if [ "$isPR" = true ]
-          then
-            echo 'states=["RI", "DE"]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'states=["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]' >> "$GITHUB_OUTPUT"
-          fi
   states:
     runs-on: ubuntu-latest
-    needs: define-matrix
     strategy:
       fail-fast: false
       matrix:
-        state: ${{ fromJSON(needs.define-matrix.outputs.states) }}
+        state: ["RI", "DE"]
     steps:
       - uses: actions/checkout@v4
 
@@ -76,33 +43,3 @@ jobs:
         with:
           name: ${{ matrix.state }}
           path: fia/parquet/*
-  
-  combine:
-    runs-on: ubuntu-latest
-    needs: states
-    # env:
-    #   ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      # - uses: r-lib/actions/setup-r@v2
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: fia/parquet
-          merge-multiple: true
-      - name: Create zip file
-        run: zip -r all_states.zip fia/parquet
-      # - name: Push to Zenodo
-      #   if: ${{ github.event_name != "pull_request" }}
-      #   run: Rscript -e 'source("scripts/03-upload_parquet_db_zenodo.R")'
-      # - name: Check db
-      #   run: Rscript -e 'source("scripts/04-check_db.R")'
-      # - name: Check saplings
-      #   run: Rscript -e 'source("scripts/05-check_saplings.R")'
-      # - name: Check annualized
-      #   run: Rscript -e 'source("scripts/06-check-annualized.R")'
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: all_states.zip
-          path: all_states.zip

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ To install from GitHub:
 pak::pak("Evans-Ecology-Lab/forestTIME-builder")
 ```
 
+## I just want the data!
+
+If you just want to download annualized FIA tables produced by `forestTIME.builder`, head over to the most recent [release](https://github.com/Evans-Ecology-Lab/forestTIME-automation/releases/) on github.com/Evans-Ecology-Lab/forestTIME-automation to download parquet files.  They can be read into R as dataframes with `nanoparquet`, for example.
+
 ## Contributing
 
 If you'd like to make modifications to the functions in this package, you are welcome to do so.  However, it would be ideal if those modifications could be incorporated into this package to benefit everyone using it and to keep a single "source of truth" for this workflow. 
 
 If you are brand new to R package development or using GitHub, I recommend you start by opening an issue to make a suggestion or report a bug.  If you have some familiarity with R code and feel comfortable, feel free to make a pull request. I recommend using `usethis` to handle this process if you are not familiar with git and GitHub.  Start by [setting up your GitHub credentials](https://usethis.r-lib.org/articles/git-credentials.html) and then use `usethis::create_from_github("Evans-Ecology-Lab/forestTIME-builder")` to (possibly fork) and clone this repository. The `usethis` package has some [nice documentation](https://usethis.r-lib.org/articles/pr-functions.html) on how to create pull requests using it's `pr_*()` functions, namely `pr_init()` to create a new branch, `pr_push()` to actually open the pull request on GitHub, and `pr_finish()` to clean things up after yoru pull request is merged.
 
-## Automation
-
-Eventually, this repository will contain a GitHub workflow to automate the interpolation and carbon estimation for all states and provide the resulting annualized dataset(s).
 
 ## Citation
 


### PR DESCRIPTION
Now annualized data is automated in the forestTIME-automation repo, so this PR adds a link to it in the README and changes the `run-workflow.yml` action to only run on PRs and only with DE and RI as a test.