### PR TITLE
keep MORTYR_eff and midpt_dead columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # forestTIME.builder (development version)
 
+- The results of `fia_annualize()` now include a `midpt_dead` column which is the year a tree is estimated to be dead when `MORTYR` is not used.  If `use_mortyr = TRUE` it *also* includes a `MORTYR_eff` ("effective MORTYR") column, which is usually `MORTYR` except when a tree is alive in the recorded `MORTYR`, in which case it is `MORTYR` + 1
 - `fia_tidy()` now only keeps base-intensity plots (`INTENSITY == 1 & SUBCYCLE != 0 & SUBCYCLE != 99`).
 - Fixed a bug that was causing `TPA_UNADJ` to not be populated for all trees in states that use macroplots ([#160](https://github.com/Evans-Ecology-Lab/forestTIME-builder/issues/160)).
 - Fixed a bug in `fia_split_composite_ids()` that caused it to fail when `tree_ID` was `NA` (as it is in conditions with no observations). It now falls back on the information in `plot_ID` when `tree_ID` is in the data frame but `NA` ([#149](https://github.com/Evans-Ecology-Lab/forestTIME-builder/issues/149)).

--- a/man/adjust_mortality.Rd
+++ b/man/adjust_mortality.Rd
@@ -13,7 +13,11 @@ adjust_mortality(data_interpolated, use_mortyr = TRUE)
 tree was dead?}
 }
 \value{
-a tibble
+a tibble with additional columns \code{MORTYR_eff}, which is \code{MORTYR} but
+adjusted forward a year in the case when the tree was alive in the recorded
+\code{MORTYR}, and \code{midpt_dead}, which is just the midpoint year (rounded down)
+between the inventory year when a tree was last observed a live and the
+inventory year it was first observed dead.
 }
 \description{
 This is an "internal" function—most users will want to run \code{\link[=fia_annualize]{fia_annualize()}}

--- a/tests/testthat/test-adjust_mortality.R
+++ b/tests/testthat/test-adjust_mortality.R
@@ -186,6 +186,19 @@ test_that("MORTYR gets nudged to next year if tree is alive", {
       pull(STATUSCD),
     2
   )
+
+  expect_equal(
+    data_adj |>
+      filter(tree_ID == "8_1_119_80086_3_12") |>
+      pull(MORTYR_eff) |>
+      unique(),
+    data_adj |>
+      filter(tree_ID == "8_1_119_80086_3_12") |>
+      pull(MORTYR) |>
+      unique() +
+      1
+  )
+
   expect_equal(
     data_adj |>
       filter(


### PR DESCRIPTION
Modifies `adjust_mortality()` (and therefore `fia_annualize()`) to keep the `MORTYR_eff` and `midpt_dead` columns in the resulting output.  `MORTYR_eff` is just `MORTYR` unless the tree was alive in `MORTYR`, in which case it is `MORTYR + 1`.  `midpt_dead` is the year between the last survey a tree was alive and the first one it was dead (rounded down).  These columns could be useful for some future analysis.